### PR TITLE
Fixed hardcoded change to non-existing branch

### DIFF
--- a/ansible/roles/ui/tasks/main.yml
+++ b/ansible/roles/ui/tasks/main.yml
@@ -56,9 +56,6 @@
     clone: yes
     update: no
     
-- name: Switch branch
-  shell: cd {{ angular_home_dir }} && git checkout dev
-
 - name: Update permissions after code is cloned
   file:
     path: "{{ angular_home_dir }}"


### PR DESCRIPTION
There is a hardcoded change of the git-branch of the UI. There are multiple problems with this task

* don't use shell-tasks for git-operations - the git-module is able to perform this as well
* the branch is hardcoded (dev!) and cannot be changed - this makes the installation useless to people who want to process a standard- or production-installation
* the branch does not exist in the original source-repo and the installation fails
```
TASK [ui : Switch branch] ******************************************************
fatal: [dspace-vm]: FAILED! => {"changed": true, "cmd": "cd /ng/ngrocks && git checkout dev", "delta": "0:00:00.004255", "end": "2022-04-28 04:33:10.601434", "msg": "non-zero return code", "rc": 1, "start": "2022-04-28 04:33:10.597179", "stderr": "error: pathspec 'dev' did not match any file(s) known to git", "stderr_lines": ["error: pathspec 'dev' did not match any file(s) known to git"], "stdout": "", "stdout_lines": []}
```
---

Instead, please just use the `version` property of the existing `git` task to change the branch. (If necessary, introduce an additional variable)

```
  git:
    version: "{{ dspace_angular_version }}"
```
=> `dspace_angular_version: dev` in your own custom config