### PR TITLE
Added possibility to use proxy/apache before dspace services

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -26,3 +26,11 @@
     register: ps
 
   - debug: var=ps.stdout_lines
+
+- hosts: all
+  become: true
+  vars_files:
+      - vars/main.yml
+  roles:
+    - role: apache
+      when: install_apache

--- a/ansible/roles/apache/defaults/main.yml
+++ b/ansible/roles/apache/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+apache2_modules:
+  - rewrite
+  - headers
+  - proxy
+  - proxy_http

--- a/ansible/roles/apache/handlers/main.yml
+++ b/ansible/roles/apache/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart apache2
+  service: name=apache2 state=restarted

--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Install apache
+  apt:
+    name: ["apache2"]
+    state: "present"
+  tags:
+  - packages
+
+- name: apache - add virtual hosts
+  template:
+    src: 'dspace.conf'
+    dest: '/etc/apache2/sites-available/dspace.conf'
+  notify:
+    - restart apache2
+
+- name: apache - enabled mod
+  apache2_module:
+    name: "{{ item }}"
+    state: "present"
+  loop: '{{ apache2_modules }}'
+  notify:
+    - restart apache2
+
+- name: a2dissite default
+  file:
+    path: /etc/apache2/sites-enabled/000-default.conf
+    state: absent
+  notify:
+    - restart apache2
+
+- name: a2ensite
+  file:
+    path: '/etc/apache2/sites-enabled/dspace.conf'
+    src: '../sites-available/dspace.conf'
+    state: link
+  notify:
+    - restart apache2

--- a/ansible/roles/apache/templates/dspace.conf
+++ b/ansible/roles/apache/templates/dspace.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:{{ apache_listening_port }}>
+{% if base_path != ui_namespace and (base_path + "/") != ui_namespace %}
+        RedirectMatch "^{{ base_path }}/?$"  {{ public_client_url }}
+{% endif %}
+
+        ProxyPass {{ ui_namespace }}        {{ cfg_client_url }}
+        ProxyPassReverse {{ ui_namespace }} {{ cfg_client_url }}
+
+        ProxyPass {{ server_namespace }}        {{ cfg_server_url }}
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log 
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/ansible/roles/dspace/tasks/main.yml
+++ b/ansible/roles/dspace/tasks/main.yml
@@ -54,18 +54,18 @@
   loop:
     - [
         "^dspace.server.url=",
-        "dspace.server.url={{ cfg_server_url }}",
+        "dspace.server.url={{ public_server_url | regex_replace('/$', '') }}",
       ]
-    - ["^dspace.ui.url=", "dspace.ui.url={{ cfg_client_url }}"]
+    - ["^dspace.ui.url=", "dspace.ui.url={{ public_client_url | regex_replace('/$', '') }}"]
     - [
         "^dspace.server.url = ",
-        "dspace.server.url = {{ cfg_server_url }}",
+        "dspace.server.url = {{ public_server_url | regex_replace('/$', '') }}",
       ]
-    - ["^dspace.ui.url = ", "dspace.ui.url = {{ cfg_client_url }}"]
+    - ["^dspace.ui.url = ", "dspace.ui.url = {{ public_client_url | regex_replace('/$', '') }}"]
 
 - name: adjust more
   lineinfile:
-    line: 'dspace.ui.url = {{ client_http_protocol }}://{{ ip_client }}:{{ client_port }}'
+    line: "dspace.ui.url = {{ public_client_url | regex_replace('/$', '') }}"
     path: "{{dspace_install_dir}}/dspace/config/local.cfg"
     insertafter: EOF
 

--- a/ansible/roles/ui/files/config.dev.yml
+++ b/ansible/roles/ui/files/config.dev.yml
@@ -6,6 +6,6 @@ ui:
 
 rest:
   ssl: {{ ssl_enabled_server }}
-  host: {{ ip_server }}
-  port: {{ server_port }}
+  host: {{ public_server_host }}
+  port: {{ public_server_port }}
   nameSpace: {{ server_namespace }}

--- a/ansible/vars/main.yml
+++ b/ansible/vars/main.yml
@@ -55,7 +55,7 @@ tomcat_install_dir: /opt
 solr_download_dir: /opt/tmp/solr
 solr_install_dir: /opt/bin/solr
 ant_version: 1.10.10
-dspace_angular_version: dspace-7.2
+dspace_angular_version: main
 tomcat_version: 9.0.59
 solr_version: 8.11.1
 
@@ -82,8 +82,9 @@ server_port: 8080
 client_port: 4000
 ssl_enabled_client: false
 ssl_enabled_server: false
-ui_namespace: /
-server_namespace: /server
+base_path: ""
+ui_namespace: "{{ base_path }}/"
+server_namespace: "{{ base_path }}/server"
 admin_email: 'test@test.edu'
 admin_first_name: 'admin'
 admin_last_name: 'user'
@@ -91,9 +92,21 @@ admin_password: 'admin'
 client_http_protocol: http
 server_http_protocol: http
 
+install_apache: false
+apache_listening_port: 80
+
+public_server_host: "{{ ip_server }}"
+public_server_port: "{{ apache_listening_port if install_apache else server_port }}"
+public_server_protocol: "{{ server_http_protocol }}"
+public_server_url: "{{ public_server_protocol }}://{{ public_server_host }}{{ ':' + public_server_port if public_server_port != '80' and public_server_port != '443' else '' }}{{ server_namespace }}"
+
+public_client_host: "{{ ip_client }}"
+public_client_port: "{{ apache_listening_port if install_apache else client_port }}"
+public_client_protocol: "{{ client_http_protocol }}"
+public_client_url: "{{ public_client_protocol }}://{{ public_client_host }}{{ ':' + public_client_port if public_client_port != '80' and public_client_port != '443' else '' }}{{ ui_namespace }}"
+
 cfg_server_url: "{{ server_http_protocol }}://{{ ip_server }}:{{ server_port }}{{ server_namespace }}"
-cfg_client_url: "{{ client_http_protocol }}://{{ ip_client }}:{{ client_port }}"
-cfg_client_url_http: "{{ client_http_protocol }}://{{ ip_client }}"
+cfg_client_url: "{{ client_http_protocol }}://{{ ip_client }}:{{ client_port }}{{ ui_namespace }}"
 
 work_user:  "{{ ansible_user | default(lookup('env', 'USER')) }}"
 dspace_user: dspace


### PR DESCRIPTION
With this change, it is possible to
* install an apache-webserver that handles incoming public requests from the users and routes them to the internal dspace-services
* configure the public dspace access

It is deactivated per default and needs to be activated via
* `install_apache: true`
* adjust `base_path`, if you want to use the same path-prefix for both, frontend and backend
* adjust `ui_namespace` and `server_namespace` to your needs, including subdirectories, for example `ui_namespace: "{{ base_path }}/ui"` and `server_namespace: "{{ base_path }}/server"`